### PR TITLE
Support Windows and MacOS platforms

### DIFF
--- a/exiftool.go
+++ b/exiftool.go
@@ -18,7 +18,6 @@ var executeArg = "-execute"
 var initArgs = []string{"-stay_open", "True", "-@", "-", "-common_args"}
 var extractArgs = []string{"-j"}
 var closeArgs = []string{"-stay_open", "False", executeArg}
-var readyToken = []byte("{ready}\n")
 var readyTokenLen = len(readyToken)
 
 // ErrNotExist is a sentinel error for non existing file

--- a/platform_darwin.go
+++ b/platform_darwin.go
@@ -1,0 +1,3 @@
+package exiftool
+
+var readyToken = []byte("{ready}\r")

--- a/platform_linux.go
+++ b/platform_linux.go
@@ -1,0 +1,3 @@
+package exiftool
+
+var readyToken = []byte("{ready}\n")

--- a/platform_windows.go
+++ b/platform_windows.go
@@ -1,0 +1,3 @@
+package exiftool
+
+var readyToken = []byte("{ready}\r\n")


### PR DESCRIPTION
Each platform has different line breaking characters, so it stucks on
```golang
if !e.scanout.Scan() {
  fms[i].Err = fmt.Errorf("nothing on stdout")
  continue
}
```
waiting for **readyToken** from the scanner.
I issued this problem on Windows.