### PR TITLE
Merge stdout and stderr to see errors easier

### DIFF
--- a/exiftool.go
+++ b/exiftool.go
@@ -26,10 +26,10 @@ var ErrNotExist = errors.New("file does not exist")
 
 // Exiftool is the exiftool utility wrapper
 type Exiftool struct {
-	lock    sync.Mutex
-	stdin   io.WriteCloser
-	stdout  io.ReadCloser
-	scanout *bufio.Scanner
+	lock          sync.Mutex
+	stdin         io.WriteCloser
+	stdMergedOut  io.ReadCloser
+	scanMergedOut *bufio.Scanner
 }
 
 // NewExiftool instanciates a new Exiftool with configuration functions. If anything went
@@ -44,18 +44,19 @@ func NewExiftool(opts ...func(*Exiftool) error) (*Exiftool, error) {
 	}
 
 	cmd := exec.Command(binary, initArgs...)
+	r, w := io.Pipe()
+	e.stdMergedOut = r
+
+	cmd.Stdout = w
+	cmd.Stderr = w
 
 	var err error
 	if e.stdin, err = cmd.StdinPipe(); err != nil {
 		return nil, fmt.Errorf("error when piping stdin: %w", err)
 	}
 
-	if e.stdout, err = cmd.StdoutPipe(); err != nil {
-		return nil, fmt.Errorf("error when piping stdout: %w", err)
-	}
-
-	e.scanout = bufio.NewScanner(e.stdout)
-	e.scanout.Split(splitReadyToken)
+	e.scanMergedOut = bufio.NewScanner(r)
+	e.scanMergedOut.Split(splitReadyToken)
 
 	if err = cmd.Start(); err != nil {
 		return nil, fmt.Errorf("error when executing commande: %w", err)
@@ -77,8 +78,8 @@ func (e *Exiftool) Close() error {
 	}
 
 	var errs []error
-	if err := e.stdout.Close(); err != nil {
-		errs = append(errs, fmt.Errorf("error while closing stdout: %w", err))
+	if err := e.stdMergedOut.Close(); err != nil {
+		errs = append(errs, fmt.Errorf("error while closing stdMergedOut: %w", err))
 	}
 
 	if err := e.stdin.Close(); err != nil {
@@ -120,19 +121,19 @@ func (e *Exiftool) ExtractMetadata(files ...string) []FileMetadata {
 		fmt.Fprintln(e.stdin, f)
 		fmt.Fprintln(e.stdin, executeArg)
 
-		if !e.scanout.Scan() {
-			fms[i].Err = fmt.Errorf("nothing on stdout")
+		if !e.scanMergedOut.Scan() {
+			fms[i].Err = fmt.Errorf("nothing on stdMergedOut")
 			continue
 		}
 
-		if e.scanout.Err() != nil {
-			fms[i].Err = fmt.Errorf("error while reading stdout: %w", e.scanout.Err())
+		if e.scanMergedOut.Err() != nil {
+			fms[i].Err = fmt.Errorf("error while reading stdMergedOut: %w", e.scanMergedOut.Err())
 			continue
 		}
 
 		var m []map[string]interface{}
-		if err := json.Unmarshal(e.scanout.Bytes(), &m); err != nil {
-			fms[i].Err = fmt.Errorf("error during unmarshaling (%v): %w)", e.scanout.Bytes(), err)
+		if err := json.Unmarshal(e.scanMergedOut.Bytes(), &m); err != nil {
+			fms[i].Err = fmt.Errorf("error during unmarshaling (%v): %w)", e.scanMergedOut.Bytes(), err)
 			continue
 		}
 

--- a/exiftool_test.go
+++ b/exiftool_test.go
@@ -137,7 +137,7 @@ func TestCloseNominal(t *testing.T) {
 
 	r := readWriteCloserMock{closed: &rClosed}
 	w := readWriteCloserMock{closed: &wClosed}
-	e := Exiftool{stdin: r, stdout: w}
+	e := Exiftool{stdin: r, stdMergedOut: w}
 
 	assert.Nil(t, e.Close())
 	assert.True(t, rClosed)
@@ -149,7 +149,7 @@ func TestCloseErrorOnStdin(t *testing.T) {
 
 	r := readWriteCloserMock{closed: &rClosed, closeErr: fmt.Errorf("error")}
 	w := readWriteCloserMock{closed: &wClosed}
-	e := Exiftool{stdin: r, stdout: w}
+	e := Exiftool{stdin: r, stdMergedOut: w}
 
 	assert.NotNil(t, e.Close())
 	assert.True(t, rClosed)
@@ -161,7 +161,7 @@ func TestCloseErrorOnStdout(t *testing.T) {
 
 	r := readWriteCloserMock{closed: &rClosed}
 	w := readWriteCloserMock{closed: &wClosed, closeErr: fmt.Errorf("error")}
-	e := Exiftool{stdin: r, stdout: w}
+	e := Exiftool{stdin: r, stdMergedOut: w}
 
 	assert.NotNil(t, e.Close())
 	assert.True(t, rClosed)


### PR DESCRIPTION
### Problem
When **exiftool** reports about errors, it prints them to **stderr**. But **go-exiftool** pipes only **stdout**, so there's no way to find out what happened.

### Solution
Let's merge stdout and stderr:
```golang
cmd := exec.Command(binary, initArgs...)
r, w := io.Pipe()
e.stdMergedOut = r

cmd.Stdout = w
cmd.Stderr = w

var err error
if e.stdin, err = cmd.StdinPipe(); err != nil {
  return nil, fmt.Errorf("error when piping stdin: %w", err)
}

e.scanMergedOut = bufio.NewScanner(r)
e.scanMergedOut.Split(splitReadyToken)
```
It allows us to see error output when unmarshalling json:
```golang
if err := json.Unmarshal(e.scanMergedOut.Bytes(), &m); err != nil {
  fms[i].Err = fmt.Errorf("error during unmarshaling (%v): %w)", e.scanMergedOut.Bytes(), err)
  continue
}
```
### Warning
Closing and freeing resources statements should be reviewed after me...