### PR TITLE
Issue 6 buffer problem

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -60,6 +60,26 @@ Output :
 (...)
 ```
 
+
+## What if i get an error: "nothing on stdout"
+
+The reason might be when the token buffer is overflowed. 
+
+Try to increase the buffer size using function as a parameter by NewExiftool initialization:
+
+```go
+et, err = exiftool.NewExiftool(func(ex *exiftool.Exiftool) error {
+    ex.SetBufferSize(4064 * 1024)
+    return nil
+})
+
+if err != nil {
+    fmt.Printf("Error when intializing: %v\n", err)
+    return
+}
+defer et.Close()
+```
+
 ## Changelog
 
 - v1.1.0 : initial release


### PR DESCRIPTION
An error `nothing on stdout` is occurred in case the token buffer is overflowed.
This error comes form this part of the code:

```
if !e.scanout.Scan() {
    fms[i].Err = fmt.Errorf("nothing on stdout")
    continue
}
```

And in core it comes from this part of the code:
https://github.com/golang/go/blob/master/src/bufio/scan.go#L193
