### PR TITLE
Fix supporting of Windows and MacOS platforms

### DIFF
--- a/exiftool.go
+++ b/exiftool.go
@@ -15,7 +15,7 @@ import (
 
 var binary = "exiftool"
 var executeArg = "-execute"
-var initArgs = []string{"-stay_open", "True", "-@", "-", "-common_args"}
+var initArgs = []string{"-stay_open", "True", "-@", "-", "-common_args", "-charset", "filename=utf8"}
 var extractArgs = []string{"-j"}
 var closeArgs = []string{"-stay_open", "False", executeArg}
 var readyTokenLen = len(readyToken)

--- a/exiftool_test.go
+++ b/exiftool_test.go
@@ -98,7 +98,6 @@ func TestMultiExtract(t *testing.T) {
 }
 
 func TestSplitReadyToken(t *testing.T) {
-	readyToken := []byte("{ready}\n")
 	rt := string(readyToken)
 
 	var tcs = []struct {


### PR DESCRIPTION
In #7 we supported Windows and MacOS platforms by using platform-specific line breakers. But tests used its own variable with **readyToken**, so they failed. Now it is fixed.

Also I found a filename encoding problem on Windows: **exiftool** says file not found in **stay_open** mode. I fixed it by setting filename encoding explicitly.

Now go-exiftool passes its tests on Linux and Windows (I have no MacOS to test on).