### PR TITLE
Misc improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: go-exiftool-ci
-on: push
+on:
+  - push
+  - pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/exiftool.go
+++ b/exiftool.go
@@ -73,7 +73,7 @@ func NewExiftool(opts ...func(*Exiftool) error) (*Exiftool, error) {
 	e.scanMergedOut.Split(splitReadyToken)
 
 	if err = cmd.Start(); err != nil {
-		return nil, fmt.Errorf("error when executing commande: %w", err)
+		return nil, fmt.Errorf("error when executing command: %w", err)
 	}
 
 	return &e, nil

--- a/exiftool.go
+++ b/exiftool.go
@@ -14,7 +14,7 @@ import (
 )
 
 var executeArg = "-execute"
-var initArgs = []string{"-stay_open", "True", "-@", "-", "-common_args"}
+var initArgs = []string{"-stay_open", "True", "-@", "-"}
 var extractArgs = []string{"-j"}
 var closeArgs = []string{"-stay_open", "False", executeArg}
 var readyTokenLen = len(readyToken)
@@ -48,7 +48,12 @@ func NewExiftool(opts ...func(*Exiftool) error) (*Exiftool, error) {
 		}
 	}
 
-	args := append(initArgs, e.extraInitArgs...)
+	args := append([]string(nil), initArgs...)
+	if len(e.extraInitArgs) > 0 {
+		args = append(args, "-common_args")
+		args = append(args, e.extraInitArgs...)
+	}
+
 	cmd := exec.Command(e.exiftoolBinPath, args...)
 	r, w := io.Pipe()
 	e.stdMergedOut = r

--- a/exiftool_test.go
+++ b/exiftool_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestNewExiftoolEmpty(t *testing.T) {
+	t.Parallel()
+
 	e, err := NewExiftool()
 	assert.Nil(t, err)
 
@@ -18,6 +20,8 @@ func TestNewExiftoolEmpty(t *testing.T) {
 }
 
 func TestNewExifToolOptOk(t *testing.T) {
+	t.Parallel()
+
 	var exec1, exec2 bool
 
 	f1 := func(*Exiftool) error {
@@ -40,6 +44,8 @@ func TestNewExifToolOptOk(t *testing.T) {
 }
 
 func TestNewExifToolOptKo(t *testing.T) {
+	t.Parallel()
+
 	f := func(*Exiftool) error {
 		return fmt.Errorf("err")
 	}
@@ -61,6 +67,8 @@ func TestSingleExtract(t *testing.T) {
 	for _, tc := range tcs {
 		tc := tc // Pin variable
 		t.Run(tc.tcID, func(t *testing.T) {
+			t.Parallel()
+
 			e, err := NewExiftool()
 			assert.Nilf(t, err, "error not nil: %v", err)
 			defer e.Close()
@@ -75,6 +83,8 @@ func TestSingleExtract(t *testing.T) {
 }
 
 func TestMultiExtract(t *testing.T) {
+	t.Parallel()
+
 	e, err := NewExiftool()
 
 	assert.Nilf(t, err, "error not nil: %v", err)
@@ -169,6 +179,8 @@ func TestCloseErrorOnStdout(t *testing.T) {
 }
 
 func TestCloseExifToolNominal(t *testing.T) {
+	t.Parallel()
+
 	e, err := NewExiftool()
 
 	assert.Nil(t, err)
@@ -199,6 +211,8 @@ func (e readWriteCloserMock) Close() error {
 }
 
 func TestBuffer(t *testing.T) {
+	t.Parallel()
+
 	e, err := NewExiftool()
 	assert.Nil(t, err)
 	defer e.Close()
@@ -212,6 +226,8 @@ func TestBuffer(t *testing.T) {
 }
 
 func TestNewExifTool_WithBuffer(t *testing.T) {
+	t.Parallel()
+
 	buf := make([]byte, 128*1000)
 	e, err := NewExiftool(Buffer(buf, 64*1000))
 	assert.Nil(t, err)
@@ -223,6 +239,8 @@ func TestNewExifTool_WithBuffer(t *testing.T) {
 }
 
 func TestCharset(t *testing.T) {
+	t.Parallel()
+
 	e, err := NewExiftool()
 	assert.Nil(t, err)
 	defer e.Close()
@@ -235,6 +253,8 @@ func TestCharset(t *testing.T) {
 }
 
 func TestNewExifTool_WithCharset(t *testing.T) {
+	t.Parallel()
+
 	e, err := NewExiftool(Charset("filename=utf8"))
 	assert.Nil(t, err)
 	defer e.Close()
@@ -245,6 +265,8 @@ func TestNewExifTool_WithCharset(t *testing.T) {
 }
 
 func TestNoPrintConversion(t *testing.T) {
+	t.Parallel()
+
 	e, err := NewExiftool(NoPrintConversion())
 	assert.Nil(t, err)
 	defer e.Close()
@@ -264,6 +286,8 @@ func TestNoPrintConversion(t *testing.T) {
 }
 
 func TestExtractEmbedded(t *testing.T) {
+	t.Parallel()
+
 	eWithout, err := NewExiftool()
 	assert.Nil(t, err)
 	defer eWithout.Close()
@@ -285,6 +309,8 @@ func TestExtractEmbedded(t *testing.T) {
 }
 
 func TestExtractAllBinaryMetadata(t *testing.T) {
+	t.Parallel()
+
 	eWithout, err := NewExiftool()
 	assert.Nil(t, err)
 	defer eWithout.Close()
@@ -307,6 +333,8 @@ func TestExtractAllBinaryMetadata(t *testing.T) {
 }
 
 func TestSetExiftoolBinaryPath(t *testing.T) {
+	t.Parallel()
+
 	// default
 	eDefault, err := NewExiftool()
 	assert.Nil(t, err)

--- a/exiftool_test.go
+++ b/exiftool_test.go
@@ -168,6 +168,14 @@ func TestCloseErrorOnStdout(t *testing.T) {
 	assert.True(t, wClosed)
 }
 
+func TestCloseExifToolNominal(t *testing.T) {
+	e, err := NewExiftool()
+
+	assert.Nil(t, err)
+	assert.Nil(t, e.Close())
+}
+
+
 type readWriteCloserMock struct {
 	writeInt int
 	writeErr error


### PR DESCRIPTION
Various improvements include:
* only set `-common_args` option if there are addition init args
* fix typo
* wait for `exiftool` command to exit on `Close()`
* Run tests that call `NewExiftool` in parallel (for me, test runtimes dropped from 3-4s to ~1s)
* Run CI on push and pull requests
