### PR TITLE
fixing error opening files with UTF 8 characters in the path name

### DIFF
--- a/exiftool.go
+++ b/exiftool.go
@@ -17,7 +17,7 @@ import (
 const writeMetadataSuccessTokenLen = len(writeMetadataSuccessToken)
 
 var executeArg = "-execute"
-var initArgs = []string{"-stay_open", "True", "-@", "-"}
+var initArgs = []string{"-stay_open", "True", "-@", "-", "-common_args", "-charset", "filename=utf8"}
 var extractArgs = []string{"-j"}
 var closeArgs = []string{"-stay_open", "False", executeArg}
 var readyTokenLen = len(readyToken)


### PR DESCRIPTION
fixing error opening files with UTF 8 characters in the path name