### PR TITLE
Add debug logging option

### DIFF
--- a/exiftool.go
+++ b/exiftool.go
@@ -414,7 +414,7 @@ func SetExiftoolBinaryPath(p string) func(*Exiftool) error {
 	}
 }
 
-// Debug enables printing debug logs to stderr
+// Debug enables writing debug logs to io.Writers of your choice or os.Stderr (default)
 // Sample :
 //   e, err := NewExiftool(Debug())
 func Debug(writers ...io.Writer) func(*Exiftool) error {

--- a/exiftool.go
+++ b/exiftool.go
@@ -187,7 +187,11 @@ func (e *Exiftool) ExtractMetadata(files ...string) []FileMetadata {
 			continue
 		}
 
-		e.log("sending to exiftool STDIN:")
+		fms[i].Err = e.log("sending to exiftool STDIN:")
+		if fms[i].Err != nil {
+			continue
+		}
+
 		for _, curA := range extractArgs {
 			e.logf("\t%s\n", curA)
 			if _, err := fmt.Fprintln(e.stdin, curA); err != nil {
@@ -196,12 +200,21 @@ func (e *Exiftool) ExtractMetadata(files ...string) []FileMetadata {
 			}
 		}
 
-		e.logf("\t'%s'\n", f)
+		fms[i].Err = e.logf("\t'%s'\n", f)
+		if fms[i].Err != nil {
+			continue
+		}
+
 		if _, err := fmt.Fprintln(e.stdin, f); err != nil {
 			fms[i].Err = err
 			continue
 		}
-		e.logf("\t%s\n", executeArg)
+
+		fms[i].Err = e.logf("\t%s\n", executeArg)
+		if fms[i].Err != nil {
+			continue
+		}
+
 		if _, err := fmt.Fprintln(e.stdin, executeArg); err != nil {
 			fms[i].Err = err
 			continue

--- a/exiftool.go
+++ b/exiftool.go
@@ -173,6 +173,7 @@ func (e *Exiftool) ExtractMetadata(files ...string) []FileMetadata {
 
 	fms := make([]FileMetadata, len(files))
 
+filesLoop:
 	for i, f := range files {
 		fms[i].File = f
 
@@ -193,7 +194,11 @@ func (e *Exiftool) ExtractMetadata(files ...string) []FileMetadata {
 		}
 
 		for _, curA := range extractArgs {
-			e.logf("\t%s\n", curA)
+			fms[i].Err = e.logf("\t%s\n", curA)
+			if fms[i].Err != nil {
+				continue filesLoop
+			}
+
 			if _, err := fmt.Fprintln(e.stdin, curA); err != nil {
 				fms[i].Err = err
 				continue

--- a/exiftool_test.go
+++ b/exiftool_test.go
@@ -2,6 +2,7 @@ package exiftool
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -84,6 +85,26 @@ func TestSingleExtract(t *testing.T) {
 				assert.Equalf(t, tc.expOk[i], fm.Err == nil, "#%v different", i)
 			}
 		})
+	}
+}
+
+func TestDebug(t *testing.T) {
+	t.Parallel()
+
+	b := bytes.NewBuffer([]byte{})
+
+	e, err := NewExiftool(Debug(b))
+
+	assert.Nilf(t, err, "error not nil: %v", err)
+
+	defer e.Close()
+
+	e.ExtractMetadata("./testdata/20190404_131804.jpg")
+
+	fmt.Println(b.String())
+
+	if len(b.String()) == 0 {
+		t.Error("expected debug output")
 	}
 }
 

--- a/exiftool_test.go
+++ b/exiftool_test.go
@@ -94,14 +94,10 @@ func TestDebug(t *testing.T) {
 	b := bytes.NewBuffer([]byte{})
 
 	e, err := NewExiftool(Debug(b))
-
-	assert.Nilf(t, err, "error not nil: %v", err)
-
+	require.NoError(t, err)
 	defer e.Close()
 
 	e.ExtractMetadata("./testdata/20190404_131804.jpg")
-
-	fmt.Println(b.String())
 
 	if len(b.String()) == 0 {
 		t.Error("expected debug output")


### PR DESCRIPTION
It's a little hard to understand how the package is exercising exiftool, this debug option shows exactly what is happening on the wrapped shell and can help troubleshoot the CLI usage.

Sample Output
```
executing shell command:
	 /opt/homebrew/bin/exiftool -stay_open True -@ -
sending to exiftool STDIN:
	-j
	/path/to/file.jpg
	-execute
```