### PR TITLE
To identify exiftool's ppid

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,7 @@
 # go-exiftool
 
+**fork from https://github.com/barasher/go-exiftool**
+
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 [![Build Status](https://github.com/barasher/go-exiftool/workflows/go-exiftool-ci/badge.svg)](https://github.com/barasher/go-exiftool/actions)
 [![go report card](https://goreportcard.com/badge/github.com/barasher/go-exiftool "go report card")](https://goreportcard.com/report/github.com/barasher/go-exiftool)

--- a/cmd_mgr.go
+++ b/cmd_mgr.go
@@ -1,0 +1,18 @@
+package exiftool
+
+import "fmt"
+
+func (e *Exiftool) GetPidInfo() (int, string, error) {
+	if e == nil {
+		return 0, "", fmt.Errorf("exiftool not initialized")
+	}
+	if e.cmd == nil {
+		return 0, "", fmt.Errorf("exiftool cmd not initialized")
+	}
+
+	if e.cmd.Process == nil {
+		return 0, "", fmt.Errorf("exiftool process not initialized")
+	}
+
+	return e.cmd.Process.Pid, e.cmd.String(), nil
+}

--- a/exiftool.go
+++ b/exiftool.go
@@ -48,6 +48,7 @@ type Exiftool struct {
 	cmd                      *exec.Cmd
 	backupOriginal           bool
 	clearFieldsBeforeWriting bool
+	sourceId                 string
 }
 
 // NewExiftool instanciates a new Exiftool with configuration functions. If anything went
@@ -64,6 +65,9 @@ func NewExiftool(opts ...func(*Exiftool) error) (*Exiftool, error) {
 	}
 
 	args := append([]string(nil), initArgs...)
+	if e.sourceId != "" {
+		args = append(args, "-source_id", e.sourceId)
+	}
 	if len(e.extraInitArgs) > 0 {
 		args = append(args, "-common_args")
 		args = append(args, e.extraInitArgs...)
@@ -210,7 +214,8 @@ func (e *Exiftool) ExtractMetadata(files ...string) []FileMetadata {
 // WriteMetadata writes the given metadata for each file.
 // Any errors will be saved to FileMetadata.Err
 // Note: If you're reusing an existing FileMetadata instance,
-//       you should nil the Err before passing it to WriteMetadata
+//
+//	you should nil the Err before passing it to WriteMetadata
 func (e *Exiftool) WriteMetadata(fileMetadata []FileMetadata) {
 	e.lock.Lock()
 	defer e.lock.Unlock()
@@ -316,8 +321,9 @@ func handleWriteMetadataResponse(resp string) error {
 
 // Buffer defines the buffer used to read from stdout and stderr, see https://golang.org/pkg/bufio/#Scanner.Buffer
 // Sample :
-//  buf := make([]byte, 128*1000)
-//  e, err := NewExiftool(Buffer(buf, 64*1000))
+//
+//	buf := make([]byte, 128*1000)
+//	e, err := NewExiftool(Buffer(buf, 64*1000))
 func Buffer(buf []byte, max int) func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.bufferSet = true
@@ -329,7 +335,8 @@ func Buffer(buf []byte, max int) func(*Exiftool) error {
 
 // Charset defines the -charset value to pass to Exiftool, see https://exiftool.org/faq.html#Q10 and https://exiftool.org/faq.html#Q18
 // Sample :
-//   e, err := NewExiftool(Charset("filename=utf8"))
+//
+//	e, err := NewExiftool(Charset("filename=utf8"))
 func Charset(charset string) func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.extraInitArgs = append(e.extraInitArgs, "-charset", charset)
@@ -339,7 +346,8 @@ func Charset(charset string) func(*Exiftool) error {
 
 // Api defines an -api value to pass to Exiftool, see https://www.exiftool.org/exiftool_pod.html#Advanced-options
 // Sample :
-//   e, err := NewExiftool(Api("QuickTimeUTC"))
+//
+//	e, err := NewExiftool(Api("QuickTimeUTC"))
 func Api(apiValue string) func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.extraInitArgs = append(e.extraInitArgs, "-api", apiValue)
@@ -349,7 +357,8 @@ func Api(apiValue string) func(*Exiftool) error {
 
 // NoPrintConversion enables 'No print conversion' mode, see https://exiftool.org/exiftool_pod.html.
 // Sample :
-//   e, err := NewExiftool(NoPrintConversion())
+//
+//	e, err := NewExiftool(NoPrintConversion())
 func NoPrintConversion() func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.extraInitArgs = append(e.extraInitArgs, "-n")
@@ -359,7 +368,8 @@ func NoPrintConversion() func(*Exiftool) error {
 
 // ExtractEmbedded extracts embedded metadata from files (activates Exiftool's '-ee' paramater)
 // Sample :
-//   e, err := NewExiftool(ExtractEmbedded())
+//
+//	e, err := NewExiftool(ExtractEmbedded())
 func ExtractEmbedded() func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.extraInitArgs = append(e.extraInitArgs, "-ee")
@@ -369,7 +379,8 @@ func ExtractEmbedded() func(*Exiftool) error {
 
 // ExtractAllBinaryMetadata extracts all binary metadata (activates Exiftool's '-b' paramater)
 // Sample :
-//   e, err := NewExiftool(ExtractAllBinaryMetadata())
+//
+//	e, err := NewExiftool(ExtractAllBinaryMetadata())
 func ExtractAllBinaryMetadata() func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.extraInitArgs = append(e.extraInitArgs, "-b")
@@ -379,7 +390,8 @@ func ExtractAllBinaryMetadata() func(*Exiftool) error {
 
 // DateFormant defines the -dateFormat value to pass to Exiftool, see https://exiftool.org/ExifTool.html#DateFormat
 // Sample :
-//   e, err := NewExiftool(DateFormant("%s"))
+//
+//	e, err := NewExiftool(DateFormant("%s"))
 func DateFormant(format string) func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.extraInitArgs = append(e.extraInitArgs, "-dateFormat", format)
@@ -389,7 +401,8 @@ func DateFormant(format string) func(*Exiftool) error {
 
 // CoordFormant defines the -coordFormat value to pass to Exiftool, see https://exiftool.org/ExifTool.html#CoordFormat
 // Sample :
-//   e, err := NewExiftool(CoordFormant("%+f"))
+//
+//	e, err := NewExiftool(CoordFormant("%+f"))
 func CoordFormant(format string) func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.extraInitArgs = append(e.extraInitArgs, "-coordFormat", format)
@@ -399,6 +412,7 @@ func CoordFormant(format string) func(*Exiftool) error {
 
 // PrintGroupNames prints the group names for each tag based on the pass group number(s), (activates Exiftool's '-G' paramater)
 // Sample :
+//
 //	e, err := NewExiftool(PrintGroupNames("0"))
 func PrintGroupNames(groupNumbers string) func(*Exiftool) error {
 	return func(e *Exiftool) error {
@@ -407,10 +421,22 @@ func PrintGroupNames(groupNumbers string) func(*Exiftool) error {
 	}
 }
 
+// SetSourceId set the source id for identify source
+// Sample :
+//
+//	e, err := NewExiftool(SetSourceId("tp20240718"))
+func SetSourceId(SourceId string) func(*Exiftool) error {
+	return func(e *Exiftool) error {
+		e.sourceId = SourceId
+		return nil
+	}
+}
+
 // BackupOriginal backs up the original file when writing the file metadata
 // instead of overwriting the original (activates Exiftool's '-overwrite_original' parameter)
 // Sample :
-//   e, err := NewExiftool(BackupOriginal())
+//
+//	e, err := NewExiftool(BackupOriginal())
 func BackupOriginal() func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.backupOriginal = true
@@ -421,7 +447,8 @@ func BackupOriginal() func(*Exiftool) error {
 // ClearFieldsBeforeWriting will clear existing fields (e.g. tags) in the file before writing any
 // new tags
 // Sample :
-//   e, err := NewExiftool(ClearFieldsBeforeWriting())
+//
+//	e, err := NewExiftool(ClearFieldsBeforeWriting())
 func ClearFieldsBeforeWriting() func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		e.clearFieldsBeforeWriting = true
@@ -431,7 +458,8 @@ func ClearFieldsBeforeWriting() func(*Exiftool) error {
 
 // SetExiftoolBinaryPath sets exiftool's binary path. When not specified, the binary will have to be in $PATH
 // Sample :
-//   e, err := NewExiftool(SetExiftoolBinaryPath("/usr/bin/exiftool"))
+//
+//	e, err := NewExiftool(SetExiftoolBinaryPath("/usr/bin/exiftool"))
 func SetExiftoolBinaryPath(p string) func(*Exiftool) error {
 	return func(e *Exiftool) error {
 		if _, err := os.Stat(p); err != nil {

--- a/exiftool_test.go
+++ b/exiftool_test.go
@@ -765,3 +765,17 @@ func TestBufferTooSmallError(t *testing.T) {
 	assert.Len(t, fms, 1)
 	assert.Equal(t, ErrBufferTooSmall, fms[0].Err)
 }
+
+func TestSetSourceId(t *testing.T) {
+	t.Parallel()
+
+	e, err := NewExiftool(SetSourceId("test"))
+	pid, info, err := e.GetPidInfo()
+	fmt.Printf("%d, %s\n", pid, info)
+	assert.Nil(t, err)
+	defer e.Close()
+
+	metas := e.ExtractMetadata("./testdata/20190404_131804.jpg")
+	assert.Equal(t, 1, len(metas))
+	assert.Nil(t, metas[0].Err)
+}

--- a/exiftool_test.go
+++ b/exiftool_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -770,12 +771,25 @@ func TestSetSourceId(t *testing.T) {
 	t.Parallel()
 
 	e, err := NewExiftool(SetSourceId("test"))
+	assert.Nil(t, err)
 	pid, info, err := e.GetPidInfo()
 	fmt.Printf("%d, %s\n", pid, info)
 	assert.Nil(t, err)
-	defer e.Close()
 
-	metas := e.ExtractMetadata("./testdata/20190404_131804.jpg")
+	metas := e.ExtractMetadata("./testdata/gps.jpg")
 	assert.Equal(t, 1, len(metas))
 	assert.Nil(t, metas[0].Err)
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "cmd=")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Println(err)
+	}
+	cmdStr := string(output)
+	assert.Nil(t, err)
+	if strings.Contains(cmdStr, info) {
+		proc, _ := os.FindProcess(pid)
+		err := proc.Kill()
+		assert.Nil(t, err)
+	}
+	assert.Contains(t, cmdStr, info)
 }


### PR DESCRIPTION
Thanks for your useful tools.
I create a exiftool's pool in my program, which is very useful in high concurrency scenarios. But when my program's proccess be killed in accident,the pool will lost control.
So I want to manage them,so I want to get their pid and source program name, then when my program restart, it can check and close the previous exiftool's pool.