### PR TITLE
Add method to configure system process attributes

### DIFF
--- a/exiftool_windows_test.go
+++ b/exiftool_windows_test.go
@@ -1,0 +1,28 @@
+package exiftool
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"syscall"
+	"testing"
+)
+
+func TestSystemProcessAttributes(t *testing.T) {
+	t.Parallel()
+
+	const CreateNoWindow = 0x08000000
+
+	var sysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: CreateNoWindow,
+	}
+
+	// I don't know what a good solution is to verify the process attributes are set on the actual process
+	et, err := NewExiftool(SystemProcessAttributes(sysProcAttr))
+	require.Nil(t, err, fmt.Sprintf("%v", err))
+	defer et.Close()
+
+	assert.Equal(t, sysProcAttr, et.sysProcAttr)
+	assert.Equal(t, sysProcAttr, et.cmd.SysProcAttr)
+}


### PR DESCRIPTION
Adds a method to set system process attributes on the process used to run exiftool.

For example, on windows to run exiftool without creating a window:

```go
const CreateNoWindow = 0x08000000
var sysProcAttr = syscall.SysProcAttr{
	HideWindow:    true,
	CreationFlags: CreateNoWindow,
}
et, err := exiftool.NewExiftool(exiftool.SystemProcessAttributes(&sysProcAttr))
```

I'm not exactly sure what a good way is to test this? An option I considered was replacing `exec.Command` with a fake so that `SysProcAttr` can be inspected when the command is actually run. If that sounds okay let me know and I can do it.